### PR TITLE
Use async, fix windows timezone issues & throw errors

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,3 +11,4 @@ webpack.*
 **/.vscode
 .npmignore
 .gitignore
+dist/test.*

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -5,22 +5,33 @@ Sets the system date and time through the use of platform dependent commands.
 Only supports Windows and Linux as of now.
 
 ## Installation
+
 ```
-npm i set-system-clock -S
+npm i set-system-clock -s
 ```
 
 ## API
 
 ### `DateTimeControl.setDateTime`
+
 ```js
 // @dateTime - The date and time to set the system clock to
 DateTimeControl.setDateTime(dateTime: Date);
 ```
 
 ## Code Example
-```js
-var DateTimeControl = require('set-system-clock');
 
-// Sets the date and time to the date specified
-DateTimeControl.setDateTime(new Date('8/1/2017 13:14:12'));
+```js
+import DateTimeControl from "set-system-clock";
+// or const DateTimeControl = require("set-system-clock");
+
+// Sets the date and time to the date specified, returns a promise resolves once date/time is set
+DateTimeControl.setDateTime(new Date("8/1/2017 13:14:12"));
+```
+
+### Options:
+
+```js
+// Use Sudo (Linux only)
+DateTimeControl.setDateTime(new Date("8/1/2017 13:14:12"), { useSudo: true });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,19 @@
 			"version": "1.0.4",
 			"license": "ISC",
 			"dependencies": {
-				"dateformat": "^5.0.3"
+				"dateformat": "^4.6.3"
 			},
 			"devDependencies": {
-				"@types/dateformat": "^5.0.0",
+				"@types/dateformat": "^3.0.1",
 				"@types/node": "^18.8.2",
 				"rimraf": "^3.0.2",
 				"typescript": "^4.8.4"
 			}
 		},
 		"node_modules/@types/dateformat": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-5.0.0.tgz",
-			"integrity": "sha512-SZg4JdHIWHQGEokbYGZSDvo5wA4TLYPXaqhigs/wH+REDOejcJzgH+qyY+HtEUtWOZxEUkbhbdYPqQDiEgrXeA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-3.0.1.tgz",
+			"integrity": "sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -53,11 +53,11 @@
 			"dev": true
 		},
 		"node_modules/dateformat": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-5.0.3.tgz",
-			"integrity": "sha512-Kvr6HmPXUMerlLcLF+Pwq3K7apHpYmGDVqrxcDasBg86UcKeTSNWbEzU8bwdXnxnR44FtMhJAxI4Bov6Y/KUfA==",
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+			"integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
 			"engines": {
-				"node": ">=12.20"
+				"node": "*"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -169,9 +169,9 @@
 	},
 	"dependencies": {
 		"@types/dateformat": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-5.0.0.tgz",
-			"integrity": "sha512-SZg4JdHIWHQGEokbYGZSDvo5wA4TLYPXaqhigs/wH+REDOejcJzgH+qyY+HtEUtWOZxEUkbhbdYPqQDiEgrXeA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-3.0.1.tgz",
+			"integrity": "sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g==",
 			"dev": true
 		},
 		"@types/node": {
@@ -203,9 +203,9 @@
 			"dev": true
 		},
 		"dateformat": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-5.0.3.tgz",
-			"integrity": "sha512-Kvr6HmPXUMerlLcLF+Pwq3K7apHpYmGDVqrxcDasBg86UcKeTSNWbEzU8bwdXnxnR44FtMhJAxI4Bov6Y/KUfA=="
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+			"integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,122 +1,292 @@
 {
-  "name": "set-system-clock",
-  "version": "1.0.2",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@types/node": {
-      "version": "8.0.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.19.tgz",
-      "integrity": "sha512-VRQB+Q0L3YZWs45uRdpN9oWr82meL/8TrJ6faoKT5tp0uub2l/aRMhtm5fo68h7kjYKH60f9/bay1nF7ZpTW5g==",
-      "dev": true
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "dateformat": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-      "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc="
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "1.1.8"
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1.0.2"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2"
-      }
-    },
-    "typescript": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
-      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
-      "dev": true
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    }
-  }
+	"name": "set-system-clock",
+	"version": "1.0.4",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "set-system-clock",
+			"version": "1.0.4",
+			"license": "ISC",
+			"dependencies": {
+				"dateformat": "^5.0.3"
+			},
+			"devDependencies": {
+				"@types/dateformat": "^5.0.0",
+				"@types/node": "^18.8.2",
+				"rimraf": "^3.0.2",
+				"typescript": "^4.8.4"
+			}
+		},
+		"node_modules/@types/dateformat": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-5.0.0.tgz",
+			"integrity": "sha512-SZg4JdHIWHQGEokbYGZSDvo5wA4TLYPXaqhigs/wH+REDOejcJzgH+qyY+HtEUtWOZxEUkbhbdYPqQDiEgrXeA==",
+			"dev": true
+		},
+		"node_modules/@types/node": {
+			"version": "18.8.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
+			"integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
+			"dev": true
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true
+		},
+		"node_modules/dateformat": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-5.0.3.tgz",
+			"integrity": "sha512-Kvr6HmPXUMerlLcLF+Pwq3K7apHpYmGDVqrxcDasBg86UcKeTSNWbEzU8bwdXnxnR44FtMhJAxI4Bov6Y/KUfA==",
+			"engines": {
+				"node": ">=12.20"
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true
+		},
+		"node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"dev": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"dev": true,
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true
+		}
+	},
+	"dependencies": {
+		"@types/dateformat": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-5.0.0.tgz",
+			"integrity": "sha512-SZg4JdHIWHQGEokbYGZSDvo5wA4TLYPXaqhigs/wH+REDOejcJzgH+qyY+HtEUtWOZxEUkbhbdYPqQDiEgrXeA==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "18.8.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.2.tgz",
+			"integrity": "sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==",
+			"dev": true
+		},
+		"balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true
+		},
+		"dateformat": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-5.0.3.tgz",
+			"integrity": "sha512-Kvr6HmPXUMerlLcLF+Pwq3K7apHpYmGDVqrxcDasBg86UcKeTSNWbEzU8bwdXnxnR44FtMhJAxI4Bov6Y/KUfA=="
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true
+		},
+		"glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true
+		},
+		"rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"typescript": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+			"integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+			"dev": true
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "rimraf dist && tsc -p .",
-		"test": "npm run build && node test.js"
+		"test": "npm run build && node ./dist/test.js"
 	},
 	"repository": {
 		"type": "git",
@@ -25,12 +25,12 @@
 	},
 	"homepage": "https://github.com/ConnorChristie/Set-System-Clock#readme",
 	"devDependencies": {
-		"@types/dateformat": "^5.0.0",
+		"@types/dateformat": "^3.0.1",
 		"@types/node": "^18.8.2",
 		"rimraf": "^3.0.2",
 		"typescript": "^4.8.4"
 	},
 	"dependencies": {
-		"dateformat": "^5.0.3"
+		"dateformat": "^4.6.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
 	"types": "dist/index.d.ts",
 	"scripts": {
 		"build": "rimraf dist && tsc -p .",
-		"test": "npm run build && node ./dist/test.js"
+		"test": "npm run build && node ./dist/test.js",
+		"prepare": "npm run build"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,35 +1,36 @@
 {
-  "name": "set-system-clock",
-  "version": "1.0.4",
-  "description": "Sets the system date and time.",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "rimraf dist && tsc -p .",
-    "test": "npm run build && node test.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ConnorChristie/Set-System-Clock.git"
-  },
-  "keywords": [
-    "time",
-    "date",
-    "system",
-    "clock"
-  ],
-  "author": "Connor Christie",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/ConnorChristie/Set-System-Clock/issues"
-  },
-  "homepage": "https://github.com/ConnorChristie/Set-System-Clock#readme",
-  "devDependencies": {
-    "@types/node": "^8.0.19",
-    "rimraf": "^2.6.1",
-    "typescript": "^2.4.2"
-  },
-  "dependencies": {
-    "dateformat": "^2.0.0"
-  }
+	"name": "set-system-clock",
+	"version": "1.0.4",
+	"description": "Sets the system date and time.",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"scripts": {
+		"build": "rimraf dist && tsc -p .",
+		"test": "npm run build && node test.js"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/ConnorChristie/Set-System-Clock.git"
+	},
+	"keywords": [
+		"time",
+		"date",
+		"system",
+		"clock"
+	],
+	"author": "Connor Christie",
+	"license": "ISC",
+	"bugs": {
+		"url": "https://github.com/ConnorChristie/Set-System-Clock/issues"
+	},
+	"homepage": "https://github.com/ConnorChristie/Set-System-Clock#readme",
+	"devDependencies": {
+		"@types/dateformat": "^5.0.0",
+		"@types/node": "^18.8.2",
+		"rimraf": "^3.0.2",
+		"typescript": "^4.8.4"
+	},
+	"dependencies": {
+		"dateformat": "^5.0.3"
+	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ export class DateTimeControl {
 		return DateTimeControl.setter(date, options);
 	}
 
+	public setDateTime = DateTimeControl.setDateTime;
+
 	private static getSetter() {
 		switch (platform()) {
 			case "win32":
@@ -21,5 +23,4 @@ export class DateTimeControl {
 	}
 	private static setter = DateTimeControl.getSetter();
 }
-
 export default DateTimeControl;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,37 +1,25 @@
-import { IDateTimeControl, Controllers } from './shared';
-
-import * as os from 'os';
+import { platform } from "os";
+import setLinux from "./linux.clock";
+import setWin from "./windows.clock";
 
 export class DateTimeControl {
-    private dateTimeControl: IDateTimeControl;
-    
-    constructor() {
-        if (!this.isSupported()) {
-            return;
-        }
+	public static async setDateTime(date: Date): Promise<void>;
+	public static async setDateTime(date: Date, options?: { useSudo?: boolean }): Promise<void>;
+	public static async setDateTime(date: Date, options?: any): Promise<void> {
+		return DateTimeControl.setter(date, options);
+	}
 
-        let controller = Controllers[os.platform()];
-
-        this.dateTimeControl = new controller();
-    }
-
-    public setDateTime(dateTime: Date, options?: any) {
-        if (!this.isSupported()) {
-            return;
-        }
-
-        this.dateTimeControl.setDateTime(dateTime, options || {});
-    }
-
-    private isSupported() {
-        if (Controllers[os.platform()] === undefined) {
-            console.error('Unsupported system, unable to set system time.');
-
-            return false;
-        }
-
-        return true;
-    }
+	private static getSetter() {
+		switch (platform()) {
+			case "win32":
+				return setWin;
+			case "linux":
+				return setLinux;
+			default:
+				throw new Error("Unsupported operating system, unable to set system time.");
+		}
+	}
+	private static setter = DateTimeControl.getSetter();
 }
 
-export default new DateTimeControl();
+export default DateTimeControl;

--- a/src/linux.clock.ts
+++ b/src/linux.clock.ts
@@ -1,8 +1,8 @@
 import { exec } from "./shared";
 import * as dateFormat from "dateformat";
 
-export default async (dateTime: Date, options: { useSudo?: boolean }) => {
-	const sudo = options.useSudo ? "sudo" : "";
+export default async (dateTime: Date, options?: { useSudo?: boolean }) => {
+	const sudo = options?.useSudo ? "sudo" : "";
 
 	await exec(`${sudo} timedatectl set-ntp false`);
 	await exec(`${sudo} date -s "${dateFormat(dateTime, "UTC:mm/dd/yyyy HH:MM:ss")}" --utc`);

--- a/src/linux.clock.ts
+++ b/src/linux.clock.ts
@@ -1,14 +1,10 @@
-import { IDateTimeControl } from './shared';
+import { exec } from "./shared";
+import * as dateFormat from "dateformat";
 
-import { exec } from 'child_process';
-import * as dateFormat from 'dateformat';
+export default async (dateTime: Date, options: { useSudo?: boolean }) => {
+	const sudo = options.useSudo ? "sudo" : "";
 
-export default class LinuxDateTimeControl implements IDateTimeControl {
-    public setDateTime(dateTime: Date, options: any) {
-        let sudo = options.useSudo ? 'sudo ' : '';
-
-        exec(`${sudo}timedatectl set-ntp false`);
-        exec(`${sudo}date -s "${dateFormat(dateTime, 'UTC:mm/dd/yyyy HH:MM:ss')}" --utc`);
-        exec(`${sudo}hwclock -w --utc`);
-    }
-}
+	await exec(`${sudo} timedatectl set-ntp false`);
+	await exec(`${sudo} date -s "${dateFormat(dateTime, "UTC:mm/dd/yyyy HH:MM:ss")}" --utc`);
+	await exec(`${sudo} hwclock -w --utc`);
+};

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,3 +1,15 @@
-import { exec as _ } from "child_process";
+import { exec as execCallback } from "child_process";
 import { promisify } from "util";
-export const exec = promisify(_);
+export const exec = promisify(execCallback);
+
+export const getDateFormat = new Promise<string>((res) => {
+	let s = "";
+	const console = execCallback("date");
+	console.stdout?.on("data", (str: string) => {
+		s += str;
+		if (s.length === 69) {
+			console.kill();
+			res(s.slice(59, -2));
+		}
+	});
+});

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,16 +1,3 @@
-import WindowsDateTimeControl from './windows.clock';
-import LinuxDateTimeControl from './linux.clock';
-
-export interface IDateTimeControl {
-    setDateTime(dateTime: Date, options: any);
-}
-
-export enum Platform {
-    WINDOWS = 'win32',
-    LINUX = 'linux'
-}
-
-export const Controllers = {
-    [Platform.WINDOWS]: WindowsDateTimeControl,
-    [Platform.LINUX]: LinuxDateTimeControl
-};
+import { exec as _ } from "child_process";
+import { promisify } from "util";
+export const exec = promisify(_);

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,18 @@
+import DateTimeControl from ".";
+
+const timeDiff = (a: Date, b: Date) => {
+	const diff = a.getTime() - b.getTime();
+	if (diff < 0) return diff * -1;
+	return diff;
+};
+
+const dateToSet = new Date("7/8/2017 9:45:32 AM");
+const hrtime = process.hrtime();
+DateTimeControl.setDateTime(dateToSet).then(() => {
+	const [s, ns] = process.hrtime(hrtime);
+	console.log(`Setting time took: ${s * 1000 + ns / 1000000}ms`);
+	const newDate = new Date();
+	if (timeDiff(dateToSet, newDate) > 10) {
+		throw new Error(`Tests Failed! System time was not set correctely.\nExpected: ${dateToSet.toISOString()}\nGot: ${newDate.toISOString()}`);
+	}
+});

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,5 +1,7 @@
 import DateTimeControl from ".";
 
+const originalDateTime = new Date();
+
 const timeDiff = (a: Date, b: Date) => {
 	const diff = a.getTime() - b.getTime();
 	if (diff < 0) return diff * -1;
@@ -15,4 +17,5 @@ DateTimeControl.setDateTime(dateToSet).then(() => {
 	if (timeDiff(dateToSet, newDate) > 10) {
 		throw new Error(`Tests Failed! System time was not set correctely.\nExpected: ${dateToSet.toISOString()}\nGot: ${newDate.toISOString()}`);
 	}
+	DateTimeControl.setDateTime(originalDateTime);
 });

--- a/src/windows.clock.ts
+++ b/src/windows.clock.ts
@@ -1,11 +1,7 @@
-import { IDateTimeControl } from './shared';
+import { exec } from "./shared";
+import * as dateFormat from "dateformat";
 
-import { exec } from 'child_process';
-import * as dateFormat from 'dateformat';
-
-export default class WindowsDateTimeControl implements IDateTimeControl {
-    public setDateTime(dateTime: Date, options: any) {
-        exec(`date ${dateFormat(dateTime, 'm/d/yyyy')}`);
-        exec(`time ${dateFormat(dateTime, 'HH:MM:ss')}`);
-    }
-}
+export default async (dateTime: Date) => {
+	await exec(`date ${dateFormat(dateTime, "m/d/yyyy")}`);
+	await exec(`time ${dateFormat(dateTime, "HH:MM:ss")}`);
+};

--- a/src/windows.clock.ts
+++ b/src/windows.clock.ts
@@ -1,7 +1,7 @@
-import { exec } from "./shared";
+import { exec, getDateFormat } from "./shared";
 import * as dateFormat from "dateformat";
 
 export default async (dateTime: Date) => {
-	await exec(`date ${dateFormat(dateTime, "m/d/yyyy")}`);
+	await exec(`date ${dateFormat(dateTime, await getDateFormat)}`);
 	await exec(`time ${dateFormat(dateTime, "HH:MM:ss")}`);
 };

--- a/test.js
+++ b/test.js
@@ -1,5 +1,0 @@
-var control = require('./dist/index');
-
-control.setDateTime(new Date('7/8/2017 9:45:22 AM'));
-
-console.log(new Date());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,16 @@
 {
-    "compilerOptions": {
-        "types": [
-            "node"
-        ],
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "target": "es6",
-        "removeComments": true,
-        "preserveConstEnums": true,
-        "stripInternal": true,
-        "declaration": true,
-        "outDir": "dist",
-        "typeRoots": [
-            "node_modules/@types"
-        ]
-    },
-    "include": [
-        "src/**/*.ts"
-    ]
+	"compilerOptions": {
+		"types": ["node"],
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"target": "es6",
+		"removeComments": true,
+		"preserveConstEnums": true,
+		"stripInternal": true,
+		"declaration": true,
+		"outDir": "dist",
+		"typeRoots": ["node_modules/@types"],
+		"strict": true
+	},
+	"include": ["src/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 		"types": ["node"],
 		"module": "commonjs",
 		"moduleResolution": "node",
-		"target": "es6",
+		"target": "ESNext",
 		"removeComments": true,
 		"preserveConstEnums": true,
 		"stripInternal": true,


### PR DESCRIPTION
This PR has the following changes:
- Update dependencies
- Change `setDateTime()` and internal functions to be async and return a void promise.
  This allows waiting for the date/time to actually be set while being backwards compatible
- Adds typescript overloads for `setDateTime()`
- Windows date format is now pulled from system when setting resolving https://github.com/ConnorChristie/Set-System-Clock/issues/3
- Updated tests
- Changed unsupported os error to be thrown rather than just logged

All these changes should be fully backwards compatible and not require any changes on the user end of the library if updating